### PR TITLE
Add minimal Qt oscilloscope skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+project(Qt_Oscilloscope)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 COMPONENTS Widgets SerialPort REQUIRED)
+
+add_executable(Oscilloscope
+    src/main.cpp
+    src/MainWindow.cpp
+    src/OscilloscopeView.cpp
+    src/SerialReader.cpp
+)
+
+target_include_directories(Oscilloscope PRIVATE include)
+
+target_link_libraries(Oscilloscope Qt5::Widgets Qt5::SerialPort)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Qt_Osciloscope
+# Qt Oscilloscope
+
+This project demonstrates a simple two-channel software oscilloscope built with Qt 5.
+
+## Building
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+The resulting executable `Oscilloscope` requires Qt 5 with the `Widgets` and `SerialPort` modules.
+

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -1,0 +1,22 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include "OscilloscopeView.h"
+#include "SerialReader.h"
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+
+private slots:
+    void onSample(double ch1, double ch2);
+
+private:
+    OscilloscopeView *m_view;
+    SerialReader m_reader;
+};
+
+#endif // MAINWINDOW_H

--- a/include/OscilloscopeView.h
+++ b/include/OscilloscopeView.h
@@ -1,0 +1,43 @@
+#ifndef OSCILLOSCOPEVIEW_H
+#define OSCILLOSCOPEVIEW_H
+
+#include <QWidget>
+#include <QVector>
+#include <QMutex>
+#include <QTimer>
+
+class OscilloscopeView : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit OscilloscopeView(QWidget *parent = nullptr);
+
+    // Adds a sample to the circular buffer
+    void addSample(double ch1, double ch2);
+
+    void setZoomX(double factor); // time axis
+    void setZoomY(double factor); // voltage axis
+
+    void setTriggerLevel(double level); // trigger level for channel1
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private slots:
+    void onRefresh();
+
+private:
+    QVector<double> m_ch1;
+    QVector<double> m_ch2;
+    int m_maxSamples;
+
+    double m_zoomX;
+    double m_zoomY;
+    double m_triggerLevel;
+    bool m_triggered;
+
+    QMutex m_mutex;
+    QTimer m_refreshTimer;
+};
+
+#endif // OSCILLOSCOPEVIEW_H

--- a/include/SerialReader.h
+++ b/include/SerialReader.h
@@ -1,0 +1,29 @@
+#ifndef SERIALREADER_H
+#define SERIALREADER_H
+
+#include <QObject>
+#include <QSerialPort>
+#include <QByteArray>
+
+class SerialReader : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SerialReader(QObject *parent = nullptr);
+
+    bool start(const QString &portName, qint32 baudRate = 115200);
+    void stop();
+
+signals:
+    void newSample(double ch1, double ch2);
+    void error(const QString &msg);
+
+private slots:
+    void onReadyRead();
+
+private:
+    QSerialPort m_serial;
+    QByteArray m_buffer;
+};
+
+#endif // SERIALREADER_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,0 +1,21 @@
+#include "MainWindow.h"
+#include <QVBoxLayout>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent), m_view(new OscilloscopeView)
+{
+    QWidget *central = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(central);
+    layout->addWidget(m_view);
+    setCentralWidget(central);
+
+    connect(&m_reader, &SerialReader::newSample, this, &MainWindow::onSample);
+    // Example: start reading from COM1 with default baud
+    // m_reader.start("COM1");
+}
+
+void MainWindow::onSample(double ch1, double ch2)
+{
+    m_view->addSample(ch1, ch2);
+}
+

--- a/src/OscilloscopeView.cpp
+++ b/src/OscilloscopeView.cpp
@@ -1,0 +1,86 @@
+#include "OscilloscopeView.h"
+#include <QPainter>
+#include <QPaintEvent>
+
+OscilloscopeView::OscilloscopeView(QWidget *parent)
+    : QWidget(parent), m_maxSamples(1024), m_zoomX(1.0), m_zoomY(1.0), m_triggerLevel(0), m_triggered(false)
+{
+    m_ch1.resize(m_maxSamples);
+    m_ch2.resize(m_maxSamples);
+    connect(&m_refreshTimer, &QTimer::timeout, this, &OscilloscopeView::onRefresh);
+    m_refreshTimer.start(30); // roughly 33 FPS
+}
+
+void OscilloscopeView::addSample(double ch1, double ch2)
+{
+    QMutexLocker locker(&m_mutex);
+    m_ch1.push_back(ch1);
+    m_ch2.push_back(ch2);
+    if (m_ch1.size() > m_maxSamples) {
+        m_ch1.remove(0, m_ch1.size() - m_maxSamples);
+        m_ch2.remove(0, m_ch2.size() - m_maxSamples);
+    }
+}
+
+void OscilloscopeView::setZoomX(double factor) { m_zoomX = factor; }
+void OscilloscopeView::setZoomY(double factor) { m_zoomY = factor; }
+void OscilloscopeView::setTriggerLevel(double level) { m_triggerLevel = level; }
+
+void OscilloscopeView::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+    QPainter p(this);
+
+    p.fillRect(rect(), Qt::black);
+
+    // Draw grid
+    p.setPen(QPen(QColor(40, 40, 40)));
+    const int gridSpacing = 50;
+    for (int x = 0; x < width(); x += gridSpacing)
+        p.drawLine(x, 0, x, height());
+    for (int y = 0; y < height(); y += gridSpacing)
+        p.drawLine(0, y, width(), y);
+
+    p.setClipRect(rect());
+
+    // Draw channels
+    QMutexLocker locker(&m_mutex);
+    if (m_ch1.isEmpty())
+        return;
+
+    const int sampleCount = m_ch1.size();
+    auto mapX = [&](int idx) {
+        return width() - (sampleCount - idx) * m_zoomX;
+    };
+    auto mapY = [&](double val) {
+        return height()/2 - val * m_zoomY;
+    };
+
+    p.setRenderHint(QPainter::Antialiasing);
+    // Channel 1
+    p.setPen(QPen(Qt::green));
+    QPainterPath path1;
+    path1.moveTo(mapX(0), mapY(m_ch1[0]));
+    for (int i = 1; i < sampleCount; ++i)
+        path1.lineTo(mapX(i), mapY(m_ch1[i]));
+    p.drawPath(path1);
+
+    // Channel 2
+    p.setPen(QPen(Qt::red));
+    QPainterPath path2;
+    path2.moveTo(mapX(0), mapY(m_ch2[0]));
+    for (int i = 1; i < sampleCount; ++i)
+        path2.lineTo(mapX(i), mapY(m_ch2[i]));
+    p.drawPath(path2);
+
+    // Trigger line
+    p.setPen(QPen(Qt::yellow, 1, Qt::DashLine));
+    int trigY = mapY(m_triggerLevel);
+    p.drawLine(0, trigY, width(), trigY);
+}
+
+void OscilloscopeView::onRefresh()
+{
+    update();
+}
+

--- a/src/SerialReader.cpp
+++ b/src/SerialReader.cpp
@@ -1,0 +1,50 @@
+#include "SerialReader.h"
+#include <QTextStream>
+
+SerialReader::SerialReader(QObject *parent)
+    : QObject(parent)
+{
+    connect(&m_serial, &QSerialPort::readyRead, this, &SerialReader::onReadyRead);
+}
+
+bool SerialReader::start(const QString &portName, qint32 baudRate)
+{
+    if (m_serial.isOpen())
+        m_serial.close();
+
+    m_serial.setPortName(portName);
+    m_serial.setBaudRate(baudRate);
+
+    if (!m_serial.open(QIODevice::ReadOnly)) {
+        emit error(tr("Cannot open port %1").arg(portName));
+        return false;
+    }
+
+    m_buffer.clear();
+    return true;
+}
+
+void SerialReader::stop()
+{
+    if (m_serial.isOpen())
+        m_serial.close();
+}
+
+void SerialReader::onReadyRead()
+{
+    m_buffer.append(m_serial.readAll());
+    int idx;
+    while ((idx = m_buffer.indexOf('\n')) != -1) {
+        QByteArray line = m_buffer.left(idx).trimmed();
+        m_buffer.remove(0, idx + 1);
+        QList<QByteArray> parts = line.split(',');
+        if (parts.size() >= 2) {
+            bool ok1, ok2;
+            double ch1 = parts[0].toDouble(&ok1);
+            double ch2 = parts[1].toDouble(&ok2);
+            if (ok1 && ok2)
+                emit newSample(ch1, ch2);
+        }
+    }
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,10 @@
+#include <QApplication>
+#include "MainWindow.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- implement `OscilloscopeView` widget for drawing two channels with zoom and trigger features
- implement `SerialReader` using `QSerialPort` for async data reading
- add a simple `MainWindow` and application entry point
- provide basic `CMakeLists.txt` and build instructions

## Testing
- `cmake ..` *(fails: Could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_68546e82ede4832fb70cfdf5a184ab69